### PR TITLE
change wording: React component -> class component

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-component-with-composition.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-component-with-composition.english.md
@@ -15,7 +15,7 @@ When React encounters a custom HTML tag that references another component (a com
 
 ## Instructions
 <section id='instructions'>
-In the code editor, there is a simple functional component called <code>ChildComponent</code> and a React component called <code>ParentComponent</code>. Compose the two together by rendering the <code>ChildComponent</code> within the <code>ParentComponent</code>. Make sure to close the <code>ChildComponent</code> tag with a forward slash.
+In the code editor, there is a simple functional component called <code>ChildComponent</code> and a class component called <code>ParentComponent</code>. Compose the two together by rendering the <code>ChildComponent</code> within the <code>ParentComponent</code>. Make sure to close the <code>ChildComponent</code> tag with a forward slash.
 <strong>Note:</strong>&nbsp;<code>ChildComponent</code> is defined with an ES6 arrow function because this is a very common practice when using React. However, know that this is just a function. If you aren't familiar with the arrow function syntax, please refer to the JavaScript section.
 </section>
 


### PR DESCRIPTION
Hi,

I noticed that in the instructions it is written that in the code editor there is a functional component and a React component. I do believe this is a typo as both are React components, just defined differently. Therefore, the sentence should be "...there is a simple functional component called ChildComponent and a class component called ParentComponent...".

Theo

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
